### PR TITLE
Fix multiselect dropdown bug

### DIFF
--- a/frontend/src/MultipleSelect.js
+++ b/frontend/src/MultipleSelect.js
@@ -28,11 +28,12 @@ export default function MultipleSelect({
   }
 
   if (showAs === "Dropdown") {
-    const options = possibleValues.filter(value => !answers.includes(value))
+    const menuOptions = possibleValues.filter(value => !answers.includes(value));
 
     display = <MultipleSelectDropdown
+      possibleValues={possibleValues}
       answers={answers}
-      options={options}
+      options={menuOptions}
       setValue={setValue}
       questionIdx={questionIdx}
     />;

--- a/frontend/src/MultipleSelectDropdown.js
+++ b/frontend/src/MultipleSelectDropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import "./MultipleSelectDropdown.css";
 import Button from "@material-ui/core/Button";
 import Menu from "@material-ui/core/Menu";
@@ -6,6 +6,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Chip from "@material-ui/core/Chip";
 
 export default function MultiSelectDropdown({
+  possibleValues,
   answers,
   options,
   setValue,
@@ -13,7 +14,18 @@ export default function MultiSelectDropdown({
 }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [menuOptions, _setMenuOptions] = useState(options);
+  const [loadedAnswers, setLoadedAnswers] = useState(false);
   const [selectedOptions, setSelectedOptions] = useState(answers);
+
+  useEffect(() => {
+    if (!loadedAnswers) {
+      answers.forEach(answer => {
+        const optionIdx = possibleValues.indexOf(answer);
+        setValue(`${questionIdx}-${optionIdx}`, true);
+        setLoadedAnswers(true);
+      });
+    }
+  })
 
   const menuRef = useRef(menuOptions);
 
@@ -31,7 +43,7 @@ export default function MultiSelectDropdown({
     setMenuOptions(newData);
     const newOptions = selectedOptions.concat([option]);
     setSelectedOptions(newOptions);
-    const optionIdx = options.indexOf(option);
+    const optionIdx = possibleValues.indexOf(option);
     setValue(`${questionIdx}-${optionIdx}`, true);
     setAnchorEl(null);
   };
@@ -44,11 +56,8 @@ export default function MultiSelectDropdown({
     const newMenuOptions = menuOptions.concat([option]).sort();
     setMenuOptions(newMenuOptions);
     const newSelectedOptions = selectedOptions
-      .filter(opt => {
-        return opt !== option;
-      })
-      .sort();
-    const optionIdx = options.indexOf(option);
+      .filter(opt => opt !== option);
+    const optionIdx = possibleValues.indexOf(option);
     setValue(`${questionIdx}-${optionIdx}`, false);
     setSelectedOptions(newSelectedOptions);
   };

--- a/frontend/src/MultipleSelectDropdown.js
+++ b/frontend/src/MultipleSelectDropdown.js
@@ -21,7 +21,7 @@ export default function MultiSelectDropdown({
     if (!loadedAnswers) {
       answers.forEach(answer => {
         const optionIdx = possibleValues.indexOf(answer);
-        setValue(`${questionIdx}-${optionIdx}`, true);
+        setValue(`${questionIdx}-${optionIdx}`, answer);
         setLoadedAnswers(true);
       });
     }
@@ -44,7 +44,7 @@ export default function MultiSelectDropdown({
     const newOptions = selectedOptions.concat([option]);
     setSelectedOptions(newOptions);
     const optionIdx = possibleValues.indexOf(option);
-    setValue(`${questionIdx}-${optionIdx}`, true);
+    setValue(`${questionIdx}-${optionIdx}`, option);
     setAnchorEl(null);
   };
 

--- a/frontend/src/utils/formUtils.js
+++ b/frontend/src/utils/formUtils.js
@@ -6,17 +6,14 @@ export const formatData = (data, questions) => {
       formattedData[question.fieldName] = data[idx];
     } else {
       const [questionIdx, choiceIdx] = idx.split("-");
-      const { fieldName, possibleValues } = questions[questionIdx]
-      const answer = possibleValues[choiceIdx]
+      const { fieldName, possibleValues } = questions[questionIdx];
+      const answer = possibleValues[choiceIdx];
       if (!formattedData[fieldName]) {
-        if (data[idx]) {
-          formattedData[fieldName] = [answer];
-        }
-      } else {
-        if (data[idx]) {
-          const newValue = formattedData[fieldName].concat([answer])
-          formattedData[fieldName] = newValue;
-        }
+        formattedData[fieldName] = [];
+      }
+      if (data[idx]) {
+        const newValue = formattedData[fieldName].concat([answer]);
+        formattedData[fieldName] = newValue;
       }
     }
   };


### PR DESCRIPTION
This PR fixes a bug that caused incorrect values to be saved when updating answers to questions that use a multi-select dropdown menu. The questions on the form that were affected are:

- Please select any language(s) you have verbal fluency with:
- What specialized skills do you have that you might want to share with the community?

### Bug description
- When a user selects additional answer choices from the menu and then submits the form, any previous selections from the menu that loaded with the form aren't saved. 
- When a user deselects all previously loaded answer choices from the menu and then submits the form, no change occurs.

### Correct functionality
#### When a user selects additional answer choices from the menu, with previously loaded selections
> ![Fix multiselect dropdown bug1](https://user-images.githubusercontent.com/6953434/88745727-b5ef4a80-d118-11ea-9c19-8fc5e8738d80.gif)

#### When a user deselects all previously loaded answer choices
> ![Fix multiselect dropdown bug2](https://user-images.githubusercontent.com/6953434/88746382-6b6ecd80-d11a-11ea-97e9-13b80b23004a.gif)


