### PR TITLE
Touch up login message

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -51,14 +51,14 @@ app.post("/api/v1/auth", async (req, res) => {
     if (loginType == "phone") {
       sendSMS(
         loginValue,
-        `Here's your login link to the Astoria Mutual Aid Volunteer Portal!\n\n${loginLink}`
+        `Astoria Mutual Aid thanks you for helping lift up the community!\nHere's your Volunteer Portal login link.\n\n${loginLink}`
       );
     } else if (loginType == "email") {
       sendEmail(
         loginValue,
         "Log in to Astoria Mutual Aid Volunteer Portal",
-        `Here's your login link to the Astoria Mutual Aid Volunteer Portal! ${loginLink}`,
-        `Here's your login link to the Astoria Mutual Aid Volunteer Portal!<br><br>${loginLink}`
+        `Thanks for volunteering with Astoria Mutual Aid! We deeply appreciate your help lifting up the community.\n\nHere's your Volunteer Portal login link.\n\n${loginLink}`,
+        `Thanks for volunteering with Astoria Mutual Aid! We deeply appreciate your help lifting up the community.<br><br>Here's your Volunteer Portal login link.<br><br>${loginLink}`
       );
     }
 


### PR DESCRIPTION
Add some emotion-based text to the login messages, thanking volunteers
for their service, and hopefully providing some encouragement and a
human touch.

The text for the text message and the email is a bit different.

The text message text is much shorter, trying not to take up too much
space in a narrow chat bubble. It also has "Astoria Mutual Aid" first,
to better guarantee that it will appear in message summaries, so folks
will hopefully have a better sense of the nature of the text at a
glance.

The email version is a bit wordier, but not by much. Since we have the
luxury of clearly stating the sender in the subject line, and email
having more room to breath than text in general, use more natural
language to thank the volunteers.